### PR TITLE
Fix autogenerated graph labels for compliance

### DIFF
--- a/schema/scaffold/1.0.0.json
+++ b/schema/scaffold/1.0.0.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://github.com/DbCrWk/graph-norm/schema/scaffold/1.0.0.json",
+    "$id": "https://raw.githubusercontent.com/DbCrWk/graph-norm/development/schema/scaffold/1.0.0.json",
     "version": "1.0.0",
     "title": "Grano Scaffold",
     "description": "A grano scaffold file to describe a graph sequence",

--- a/src/cli/workflow/generate.js
+++ b/src/cli/workflow/generate.js
@@ -59,10 +59,10 @@ function generate(
         ? Array.from(
             { length }, (x, i) => {
                 debug('Graph entry created', { index: i });
-                return ({ label: (i + 1).toString(), edges: generateEdgeSet() });
+                return ({ label: `g${(i + 1).toString()}`, edges: generateEdgeSet() });
             },
         )
-        : [{ label: '1', edges: base.edges }];
+        : [{ label: 'g1', edges: base.edges }];
     const graphs = {};
     graphList.forEach(g => {
         graphs[g.label] = g;


### PR DESCRIPTION
Currently, our generate workflow creates graphs with labels that are just a number as a string. However, this is not compliant with our graphs schema, as graphs have to begin with a letter.

Closes #19